### PR TITLE
Update continous deployment workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,10 +62,6 @@ jobs:
                 include:
                 -   python-version: '3.8'
                     phonopy-version: '2.16.1'
-                -   python-version: '3.9'
-                    phonopy-version: '2.17.0'
-                -   python-version: '3.10'
-                    phonopy-version: '2.18.0'
                 -   python-version: '3.11'
                     phonopy-version: '2.19.0'
 


### PR DESCRIPTION
The continous deployment is very slow and as it
is testing different python environments with different phonopy versions. This is now limited to the extrema of the supported versions.