### PR TITLE
Update github workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,10 +16,10 @@ jobs:
         -   name: Checkout source
             uses: actions/checkout@v2
 
-        -   name: Set up Python 3.8
+        -   name: Set up Python 3.9
             uses: actions/setup-python@v2
             with:
-                python-version: '3.8'
+                python-version: '3.9'
 
         -   name: Validate the tag version against the package version
             run: python .github/workflows/validate_release_tag.py $GITHUB_REF
@@ -43,7 +43,7 @@ jobs:
         -   name: Set up Python
             uses: actions/setup-python@v2
             with:
-                python-version: '3.8'
+                python-version: '3.9'
 
         -   name: Install Python dependencies
             run: pip install -e .[pre-commit,tests]
@@ -60,7 +60,7 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                -   python-version: '3.8'
+                -   python-version: '3.9'
                     phonopy-version: '2.16.1'
                 -   python-version: '3.11'
                     phonopy-version: '2.19.0'
@@ -109,10 +109,10 @@ jobs:
         -   name: Checkout source
             uses: actions/checkout@v2
 
-        -   name: Set up Python 3.8
+        -   name: Set up Python 3.9
             uses: actions/setup-python@v2
             with:
-                python-version: '3.8'
+                python-version: '3.9'
 
         -   name: Install flit
             run: pip install flit~=3.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         -   name: Set up Python
             uses: actions/setup-python@v2
             with:
-                python-version: '3.8'
+                python-version: '3.10'
 
         -   name: Install python dependencies
             run: pip install -e .[pre-commit,tests]


### PR DESCRIPTION
The latest version of aiida-core dropped support
for python 3.8. As our code still supports python 3.8, while not being incompatible with later and previous versions of its dependencies, we here only update
the github workflows to use python versions supported by the latest version of aiida-core.