### PR TITLE
`Docs`: fix HV setup name :notebook:

### DIFF
--- a/docs/source/3_iraman.ipynb
+++ b/docs/source/3_iraman.ipynb
@@ -377,7 +377,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see that the values are converged within 0.1 Å with all three steps."
+    "We can see that the values are converged within 0.1 Å$^2$ with all three steps."
    ]
   },
   {
@@ -405,7 +405,7 @@
     }
    ],
    "source": [
-    "polarized_intensities, unpolarized_intensities, frequencies, labels = vibro.run_powder_raman_intensities(frequency_laser=532, temperature=300)\n",
+    "polarized_intensities, depolarized_intensities, frequencies, labels = vibro.run_powder_raman_intensities(frequency_laser=532, temperature=300)\n",
     "print(frequencies, \"\\n\", labels)"
    ]
   },
@@ -438,7 +438,7 @@
    "source": [
     "from aiida_vibroscopy.utils.plotting import get_spectra_plot\n",
     "\n",
-    "total_intensities =  polarized_intensities + unpolarized_intensities\n",
+    "total_intensities =  polarized_intensities + depolarized_intensities\n",
     "plt = get_spectra_plot(frequencies, total_intensities)\n",
     "plt.show()"
    ]
@@ -641,7 +641,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.16"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/docs/source/howto/postprocess.md
+++ b/docs/source/howto/postprocess.md
@@ -25,16 +25,17 @@ from aiida.orm import load_code
 
 vibro = load_node(IDENTIFIER) # a VibrationalData node
 
-polarized_intensities, unpolarized_intensities, frequencies, labels = vibro.run_powder_raman_intensities(frequency_laser=532, temperature=300)
+polarized_intensities, depolarized_intensities, frequencies, labels = vibro.run_powder_raman_intensities(frequency_laser=532, temperature=300)
 ```
 
-The total powder intensity will be the some of the polarized and unpolarized intensities:
+The total powder intensity will be the some of the polarized (backscattering geometry)
+and depolarized (90º geometry) intensities:
 
 ```python
-total = polarized_intensities + unpolarized_intensities
+total = polarized_intensities + depolarized_intensities
 ```
 
-The infrared in a similar way, but no distinction between polarized and unpolarized, and no laser frequency and temperature inputs:
+The infrared in a similar way, but no distinction between polarized and depolarized, and no laser frequency and temperature inputs:
 
 ```python
 intensities, frequencies, labels = vibro.run_powder_ir_intensities()

--- a/src/aiida_vibroscopy/data/vibro_mixin.py
+++ b/src/aiida_vibroscopy/data/vibro_mixin.py
@@ -401,7 +401,7 @@ class VibrationalMixin:
     ) -> tuple:
         """Return powder Raman intensities.
 
-        ..important: it computes the common setups of polarized (HH) and unpolarized (HV)
+        ..important: it computes the common setups of polarized (HH) and depolarized (HV)
             scattering. To obtain the total powder intensities, sum the two returned arrays of the intensities.
 
         .. note:: Units are:


### PR DESCRIPTION
The `unpolarized` name for the HV setup was wrong. The correct nomenclature is `depolarized`.