### PR TITLE
Fix integer sigma in multi-broadening functions

### DIFF
--- a/src/aiida_vibroscopy/utils/broadenings.py
+++ b/src/aiida_vibroscopy/utils/broadenings.py
@@ -49,7 +49,7 @@ def multilorentz(x_range: np.ndarray, peaks: list[float], intensities: list[floa
             raise ValueError("length of `gammas` and `peaks` doesn't match")
         sigmas = deepcopy(gammas)
     else:
-        sigmas = float(gammas)
+        sigmas = [float(gammas) for _ in peaks]
 
     if len(intensities) != len(peaks):
         raise ValueError("length of `intensities` and `peaks` doesn't match")
@@ -164,7 +164,7 @@ def multilvoigt(
             raise ValueError("length of `gammas_lorentz` and `peaks` doesn't match")
         sigmas = deepcopy(gammas_lorentz)
     else:
-        sigmas = float(gammas_lorentz)
+        sigmas = [float(gammas_lorentz) for _ in peaks]
 
     if len(intensities) != len(peaks):
         raise ValueError("length of `intensities` and `peaks` doesn't match")

--- a/tests/utils/test_broadening.py
+++ b/tests/utils/test_broadening.py
@@ -20,7 +20,7 @@ def generate_lorentz_inputs():
         x_range = np.arange(0, 100, 0.1)
         peak = 50.0
         intensity = 1.0
-        sigma = 10.0
+        sigma = 10
 
         if multi:
             peak = [20.0, 30.0, 40.0]


### PR DESCRIPTION
There was a bug when singled-value sigma/gamma were provided as integers for the peaks in multi-broadening functions. A list wasn't generated properly.