### PR TITLE
Docs: fix coordinates in how-tos

### DIFF
--- a/docs/source/2_dielectric.ipynb
+++ b/docs/source/2_dielectric.ipynb
@@ -588,7 +588,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.16"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -141,6 +141,8 @@ html_theme_options = {
     'repository_url': 'https://github.com/bastonero/aiida-vibroscopy',
     'github_url': 'https://github.com/bastonero/aiida-vibroscopy',
     'use_edit_page_button': True,
+    'use_download_button': True,
+    'use_sidenotes': True,
     'logo': {
         'text': 'AiiDA Vibroscopy',
         'image_light': '_static/vibroscopy_logo.png',

--- a/docs/source/howto/postprocess.md
+++ b/docs/source/howto/postprocess.md
@@ -93,11 +93,16 @@ snippet
 ```python
 import numpy as np
 
-cell = vibro.get_primitive_cell().cell
+cell = vibro.get_unitcell().cell
 
 incoming_cartesian = [0,0,1]
 inv_cell = np.linalg.inv(cell)
-incoming = np.dot(invcell, incoming_cartesian)
+incoming = np.dot(invcell.T, incoming_cartesian)
+```
+For the q-direction instead you need to transform them into reciprocal space crystal coordinates, as follows
+```python
+q_nac_cartesian = [0,0,1]
+q_nac_crystal = np.dot(cell, q_nac_cartesian)
 ```
 :::
 


### PR DESCRIPTION
After the change in unit cell coordinates, the how-tos were not updated. Here, I also add the transformation for the q-direction, which is referred to the reciprocal space.