### PR TITLE
DevOps: fix tests for dependencies updates

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,16 +10,14 @@
 import pathlib
 import time
 
-# Load the dummy profile even if we are running locally, this way the documentation will succeed even if the current
-# default profile of the AiiDA installation does not use a Django backend.
-from aiida.manage.configuration import load_documentation_profile
+from aiida.manage.configuration import Profile, load_profile
+
+load_profile(Profile('docs', {'process_control': {}, 'storage': {}}))
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 import aiida_vibroscopy
-
-load_documentation_profile()
 
 # -- Project information -----------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 readme = 'README.md'
 license = {file = 'LICENSE.txt'}
 classifiers = [
-    'Development Status :: 4 - Beta',
+    'Development Status :: 5 - Production/Stable',
     'Framework :: AiiDA',
     'License :: Other/Proprietary License',
     'Operating System :: POSIX :: Linux',
@@ -47,13 +47,13 @@ tests = [
     'pytest-regressions~=2.3',
 ]
 docs = [
-    'myst-nb@git+https://github.com/executablebooks/MyST-NB.git',
+    'myst-nb~=1.0.0',
     'sphinx~=6.2.1',
     'sphinx-copybutton~=0.5.2',
     'sphinx-book-theme~=1.0.1',
     'sphinx-design~=0.4.1',
     'sphinxcontrib-details-directive~=0.1.0',
-    'sphinx-autoapi~=2.0.1',
+    'sphinx-autoapi~=3.0.0',
     'myst_parser~=1.0.0',
     'sphinx-togglebutton',
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,7 +179,7 @@ def sssp(aiida_profile, generate_upf_data):
                 'cutoff_rho': 240.0,
             }
 
-        label = 'SSSP/1.2/PBEsol/efficiency'
+        label = 'SSSP/1.3/PBEsol/efficiency'
         family = SsspFamily.create_from_folder(dirpath, label)
 
     family.set_cutoffs(cutoffs, stringency, unit='Ry')

--- a/tests/workflows/protocols/test_dielectric/test_default.yml
+++ b/tests/workflows/protocols/test_dielectric/test_default.yml
@@ -4,6 +4,7 @@ property: raman
 scf:
   kpoints_distance: 0.4
   kpoints_force_parity: false
+  max_iterations: 5
   pw:
     code: test.quantumespresso.pw@localhost
     metadata:
@@ -11,6 +12,7 @@ scf:
         max_wallclock_seconds: 43200
         resources:
           num_machines: 1
+          num_mpiprocs_per_machine: 1
         withmpi: true
     parameters:
       CONTROL:

--- a/tests/workflows/protocols/test_harmonic/test_default.yml
+++ b/tests/workflows/protocols/test_harmonic/test_default.yml
@@ -6,6 +6,7 @@ dielectric:
   scf:
     kpoints_distance: 0.4
     kpoints_force_parity: false
+    max_iterations: 5
     pw:
       code: test.quantumespresso.pw@localhost
       metadata:
@@ -13,6 +14,7 @@ dielectric:
           max_wallclock_seconds: 43200
           resources:
             num_machines: 1
+            num_mpiprocs_per_machine: 1
           withmpi: true
       parameters:
         CONTROL:
@@ -43,6 +45,7 @@ phonon:
   scf:
     kpoints_distance: 0.15
     kpoints_force_parity: false
+    max_iterations: 5
     pw:
       code: test.quantumespresso.pw@localhost
       metadata:
@@ -50,6 +53,7 @@ phonon:
           max_wallclock_seconds: 43200
           resources:
             num_machines: 1
+            num_mpiprocs_per_machine: 1
           withmpi: true
       parameters:
         CONTROL:

--- a/tests/workflows/protocols/test_iraman/test_default.yml
+++ b/tests/workflows/protocols/test_iraman/test_default.yml
@@ -6,6 +6,7 @@ dielectric:
   scf:
     kpoints_distance: 0.4
     kpoints_force_parity: false
+    max_iterations: 5
     pw:
       code: test.quantumespresso.pw@localhost
       metadata:
@@ -13,6 +14,7 @@ dielectric:
           max_wallclock_seconds: 43200
           resources:
             num_machines: 1
+            num_mpiprocs_per_machine: 1
           withmpi: true
       parameters:
         CONTROL:
@@ -43,6 +45,7 @@ phonon:
   scf:
     kpoints_distance: 0.15
     kpoints_force_parity: false
+    max_iterations: 5
     pw:
       code: test.quantumespresso.pw@localhost
       metadata:
@@ -50,6 +53,7 @@ phonon:
           max_wallclock_seconds: 43200
           resources:
             num_machines: 1
+            num_mpiprocs_per_machine: 1
           withmpi: true
       parameters:
         CONTROL:

--- a/tests/workflows/protocols/test_phonon/test_default.yml
+++ b/tests/workflows/protocols/test_phonon/test_default.yml
@@ -4,6 +4,7 @@ displacement_generator:
 scf:
   kpoints_distance: 0.15
   kpoints_force_parity: false
+  max_iterations: 5
   pw:
     code: test.quantumespresso.pw@localhost
     metadata:
@@ -11,6 +12,7 @@ scf:
         max_wallclock_seconds: 43200
         resources:
           num_machines: 1
+          num_mpiprocs_per_machine: 1
         withmpi: true
     parameters:
       CONTROL:


### PR DESCRIPTION
aiida-quantumespresso has now came with a number of changes:
1. Default SSSP v1.3 efficiency in protocols.
2. `max_iterations` is now fixed in protocols, so that one can override it.
3. Other smal changes in the protocols that would make the tests to break.