### PR TITLE
Examples: add some useful script for IRaman

### DIFF
--- a/examples/workflows/spectra/overrides.yaml
+++ b/examples/workflows/spectra/overrides.yaml
@@ -1,0 +1,70 @@
+clean_workdir: false # whether to clean the working directiories
+dielectric:
+  clean_workdir: false
+  kpoints_parallel_distance: 0.2 # kpoints distance in Angstrom^-1 to sample the BZ parallel to the electric field. If used, it should help in converging faster the final results
+  property: raman
+  # central_difference: # if you know what you are doing, custom numerical derivatives with respect to electric field
+  #   accuracy: 2
+  #   electric_field_step: 0.0005
+  scf:
+    kpoints_distance: 0.4 # kpoints distance in Angstrom^-1 to sample the BZ
+    kpoints_force_parity: false
+    max_iterations: 5
+    pw:
+      metadata:
+        options:
+          max_wallclock_seconds: 43200
+          resources:
+            num_machines: 1
+            num_mpiprocs_per_machine: 1
+          # queue_name: partition_name # for SLURM
+          # account: account_name # for SLURM, also for project etc
+          withmpi: true
+      parameters:
+        ELECTRONS:
+          conv_thr: 2.0e-12
+          electron_maxstep: 80
+          mixing_beta: 0.4
+        SYSTEM:
+          ecutrho: 240.0
+          ecutwfc: 30.0
+  settings:
+    sleep_submission_time: 1.0
+phonon:
+  clean_workdir: false
+  displacement_generator:
+    distance: 0.01 # atomic displacements for phonon calculation, in Angstrom
+  scf:
+    kpoints_distance: 0.15 # kpoints distance in Angstrom^-1 to sample the BZ
+    kpoints_force_parity: false
+    max_iterations: 5
+    pw:
+      metadata:
+        options:
+          max_wallclock_seconds: 43200
+          resources:
+            num_machines: 1
+            num_mpiprocs_per_machine: 1
+          # queue_name: partition_name # for SLURM
+          # account: account_name # for SLURM, also for project etc
+          withmpi: true
+      settings:
+        cmdline: ['-nk', '8']
+        # gamma_only: True # to use only if KpointsData has only a mesh 1 1 1 0 0 0 (i.e. Gamma not shifted)
+      parameters:
+        ELECTRONS:
+          conv_thr: 2.0e-12
+          electron_maxstep: 80
+          mixing_beta: 0.4
+        SYSTEM:
+          ecutrho: 240.0
+          ecutwfc: 30.0
+  settings:
+    sleep_submission_time: 1.0 # waiting time in seconds between different submission of SCF calculation. Recommended to be at least 1 second, to not overload.
+settings:
+  run_parallel: true
+  use_primitive_cell: false
+symmetry:
+  distinguish_kinds: false
+  is_symmetry: true
+  symprec: 1.0e-05

--- a/examples/workflows/spectra/submit_default.py
+++ b/examples/workflows/spectra/submit_default.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=line-too-long,wildcard-import,pointless-string-statement,unused-wildcard-import
+"""Submit an IRamanSpectraWorkChain via the get_builder_from_protocol."""
+from aiida import load_profile
+from aiida.engine import submit
+from aiida.orm import *
+from aiida_quantumespresso.common.types import ElectronicType
+
+from aiida_vibroscopy.workflows.spectra.iraman import IRamanSpectraWorkChain
+
+load_profile()
+
+# =============================== INPUTS =============================== #
+# Please, change the following inputs.
+pw_code_label = 'pw@localhost'
+structure_id = 0  # PK or UUID of your AiiDA StructureData
+protocol = 'fast'  # also 'moderate' and 'precise'; 'moderate' should be good enough in general
+# ====================================================================== #
+# If you don't have a StructureData, but you have a CIF or XYZ, or similar, file
+# you can import your structure uncommenting the following:
+# from ase.io import read
+# atoms = read('/path/to/file.cif')
+# structure = StructureData(ase=atoms)
+# structure.store()
+# structure_id =  structure.pk
+# print(f"Your structure has been stored in the database with PK={structure_id}")
+
+
+def main():
+    """Submit an IRamanSpectraWorkChain calculation."""
+    code = load_code(pw_code_label)
+    structure = load_node(structure_id)
+    kwargs = {'electronic_type': ElectronicType.INSULATOR}
+
+    builder = IRamanSpectraWorkChain.get_builder_from_protocol(
+        code=code,
+        structure=structure,
+        protocol=protocol,
+        **kwargs,
+    )
+
+    calc = submit(builder)
+    print(f'Submitted IRamanSpectraWorkChain with PK={calc.pk} and UUID={calc.uuid}')
+    print('Register *at least* the PK number, e.g. in you submit script.')
+    print('You can monitor the status of your calculation with the following commands:')
+    print('  * verdi process status PK')
+    print('  * verdi process list -L IRamanSpectraWorkChain # list all running IRamanSpectraWorkChain')
+    print(
+        '  * verdi process list -ap1 -L IRamanSpectraWorkChain # list all IRamanSpectraWorkChain submitted in the previous 1 day'
+    )
+    print('If the WorkChain finishes with exit code 0, then you can inspect the outputs and post-process the data.')
+    print('Use the command')
+    print('  * verdi process show PK')
+    print('To show further information about your WorkChain. When finished, you should see some outputs.')
+    print('The main output can be accessed via `load_node(PK).outputs.vibrational_data.numerical_accuracy_*`.')
+    print('You have to complete the remaning `*`, which depends upond the accuracy of the calculation.')
+    print('See also the documentation and the reference paper for further details.')
+
+
+if __name__ == '__main__':
+    """Run script."""
+    main()

--- a/examples/workflows/spectra/submit_default_custom_kpoints.py
+++ b/examples/workflows/spectra/submit_default_custom_kpoints.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=line-too-long,wildcard-import,pointless-string-statement,unused-wildcard-import
+"""Submit an IRamanSpectraWorkChain via the get_builder_from_protocol with custom kpoints mesh."""
+from aiida import load_profile
+from aiida.engine import submit
+from aiida.orm import *
+from aiida_quantumespresso.common.types import ElectronicType
+
+from aiida_vibroscopy.workflows.spectra.iraman import IRamanSpectraWorkChain
+
+load_profile()
+
+# =============================== INPUTS =============================== #
+# Please, change the following inputs.
+pw_code_label = 'pw@localhost'
+structure_id = 0  # PK or UUID of your AiiDA StructureData
+protocol = 'fast'  # also 'moderate' and 'precise'; 'moderate' should be good enough in general
+mesh = [[2, 2, 2], [0, 0, 0]]  # k-point mesh 2x2x2 gamma centered
+# kpoints = [[2,2,2], [0.5,0.5,0.5]] # k-point mesh 2x2x2 shifted. Corresponds to 2 2 2 1 1 1 in QE input
+# ====================================================================== #
+# If you don't have a StructureData, but you have a CIF or XYZ, or similar, file
+# you can import your structure uncommenting the following:
+# from ase.io import read
+# atoms = read('/path/to/file.cif')
+# structure = StructureData(ase=atoms)
+# structure.store()
+# structure_id =  structure.pk
+# print(f"Your structure has been stored in the database with PK={structure_id}")
+
+
+def main():
+    """Submit an IRamanSpectraWorkChain calculation."""
+    code = load_code(pw_code_label)
+    structure = load_node(structure_id)
+    kwargs = {'electronic_type': ElectronicType.INSULATOR}
+
+    kpoints = KpointsData()
+    kpoints.set_kpoints_mesh(mesh[0], mesh[1])
+
+    builder = IRamanSpectraWorkChain.get_builder_from_protocol(
+        code=code,
+        structure=structure,
+        protocol=protocol,
+        **kwargs,
+    )
+
+    builder.dielectric.scf.kpoints = kpoints
+    builder.dielectric.pop('kpoints_parallel_distance', None)
+    builder.dielectric.scf.pop('kpoints_distance', None)
+    builder.phonon.scf.kpoints = kpoints
+
+    calc = submit(builder)
+    print(f'Submitted IRamanSpectraWorkChain with PK={calc.pk} and UUID={calc.uuid}')
+    print('Register *at least* the PK number, e.g. in you submit script.')
+    print('You can monitor the status of your calculation with the following commands:')
+    print('  * verdi process status PK')
+    print('  * verdi process list -L IRamanSpectraWorkChain # list all running IRamanSpectraWorkChain')
+    print(
+        '  * verdi process list -ap1 -L IRamanSpectraWorkChain # list all IRamanSpectraWorkChain submitted in the previous 1 day'
+    )
+    print('If the WorkChain finishes with exit code 0, then you can inspect the outputs and post-process the data.')
+    print('Use the command')
+    print('  * verdi process show PK')
+    print('To show further information about your WorkChain. When finished, you should see some outputs.')
+    print('The main output can be accessed via `load_node(PK).outputs.vibrational_data.numerical_accuracy_*`.')
+    print('You have to complete the remaning `*`, which depends upond the accuracy of the calculation.')
+    print('See also the documentation and the reference paper for further details.')
+
+
+if __name__ == '__main__':
+    """Run script."""
+    main()

--- a/examples/workflows/spectra/submit_default_custom_pseudos.py
+++ b/examples/workflows/spectra/submit_default_custom_pseudos.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=line-too-long,wildcard-import,pointless-string-statement,unused-wildcard-import
+"""Submit an IRamanSpectraWorkChain via the get_builder_from_protocol with custom pseudo potentials."""
+from aiida import load_profile
+from aiida.engine import submit
+from aiida.orm import *
+from aiida_quantumespresso.common.types import ElectronicType
+
+from aiida_vibroscopy.workflows.spectra.iraman import IRamanSpectraWorkChain
+
+load_profile()
+
+# =================== HOW TO STORE CUSTOM PSEUDOS ====================== #
+# Please consult also aiida-pseudo documentation.
+# Prepare a folder with the pseudopotentials you want to use, with all the elements.
+# The format should be ELEMENT.EVENTUAL_DETAILS.UPF . For instance:
+#   * Si.upf
+#   * Si.UPF
+#   * Si.us-v1.0.upf
+#   * Si.paw-rjjk.v1.3.upf
+# Please prepare a folder like:
+# -- MyPseudos
+# -- |_ Si.upf
+# -- |_ O.upf
+# -- |_ ...
+# Then run
+# $ aiida-pseudo install family MyPseudos LABEL -P pseudo.upf
+# Substitute LABEL with some significant label referring to the pseudo family you use.
+# For instance, good practices:
+#   * LDA/NC/1.1
+#   * PseudoDojo/LDA/US/standard/1.1
+# Consider that you can also install directly well tested pseudo potentials,
+# for example from the SSSP library, with the following:
+# $ aiida-pseudo install sssp -v 1.3 -x PBEsol -p efficiency
+# This will automatically download and store the pseudopotentials in a family.
+# Register the name. You can inspect the pseudo potential families you have with
+# $ aiida-pseudo list
+
+# =============================== INPUTS =============================== #
+# Please, change the following inputs.
+pw_code_label = 'pw@localhost'
+structure_id = 0  # PK or UUID of your AiiDA StructureData
+protocol = 'fast'  # also 'moderate' and 'precise'; 'moderate' should be good enough in general
+pseudo_family_name = 'LABEL'  # here the LABEL you registered before, or e.g. SSSP/1.3/PBEsol/efficiency for the SSSP example showed
+# ====================================================================== #
+# If you don't have a StructureData, but you have a CIF or XYZ, or similar, file
+# you can import your structure uncommenting the following:
+# from ase.io import read
+# atoms = read('/path/to/file.cif')
+# structure = StructureData(ase=atoms)
+# structure.store()
+# structure_id =  structure.pk
+# print(f"Your structure has been stored in the database with PK={structure_id}")
+
+
+def main():
+    """Submit an IRamanSpectraWorkChain calculation."""
+    code = load_code(pw_code_label)
+    structure = load_node(structure_id)
+    kwargs = {'electronic_type': ElectronicType.INSULATOR}
+
+    pseudo_family = load_group(pseudo_family_name)
+    pseudos = pseudo_family.get_pseudos(structure=structure)
+
+    builder = IRamanSpectraWorkChain.get_builder_from_protocol(
+        code=code,
+        structure=structure,
+        protocol=protocol,
+        **kwargs,
+    )
+
+    builder.dielectric.scf.pw.pseudos = pseudos
+    builder.phonon.scf.pw.pseudos = pseudos
+
+    calc = submit(builder)
+    print(f'Submitted IRamanSpectraWorkChain with PK={calc.pk} and UUID={calc.uuid}')
+    print('Register *at least* the PK number, e.g. in you submit script.')
+    print('You can monitor the status of your calculation with the following commands:')
+    print('  * verdi process status PK')
+    print('  * verdi process list -L IRamanSpectraWorkChain # list all running IRamanSpectraWorkChain')
+    print(
+        '  * verdi process list -ap1 -L IRamanSpectraWorkChain # list all IRamanSpectraWorkChain submitted in the previous 1 day'
+    )
+    print('If the WorkChain finishes with exit code 0, then you can inspect the outputs and post-process the data.')
+    print('Use the command')
+    print('  * verdi process show PK')
+    print('To show further information about your WorkChain. When finished, you should see some outputs.')
+    print('The main output can be accessed via `load_node(PK).outputs.vibrational_data.numerical_accuracy_*`.')
+    print('You have to complete the remaning `*`, which depends upond the accuracy of the calculation.')
+    print('See also the documentation and the reference paper for further details.')
+
+
+if __name__ == '__main__':
+    """Run script."""
+    main()

--- a/examples/workflows/spectra/submit_with_overrides.py
+++ b/examples/workflows/spectra/submit_with_overrides.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=line-too-long,wildcard-import,pointless-string-statement,unused-wildcard-import
+"""Submit an IRamanSpectraWorkChain via the get_builder_from_protocol using the overrides."""
+from pathlib import Path
+
+from aiida import load_profile
+from aiida.engine import submit
+from aiida.orm import *
+from aiida_quantumespresso.common.types import ElectronicType
+
+from aiida_vibroscopy.workflows.spectra.iraman import IRamanSpectraWorkChain
+
+load_profile()
+
+# =============================== INPUTS =============================== #
+# Please, change the following inputs.
+pw_code_label = 'pw@localhost'
+structure_id = 0  # PK or UUID of your AiiDA StructureData
+protocol = 'fast'  # also 'moderate' and 'precise'; 'moderate' should be good enough in general
+overrides_filepath = './overrides.yaml'  # should be a path, e.g. /path/to/overrides.yaml. Format is YAML
+# Consult the documentation for HOW-TO for how to use properly the overrides.
+# !!!!! FOR FULL INPUT NESTED STRUCTURE: https://aiida-vibroscopy.readthedocs.io/en/latest/topics/workflows/spectra/iraman.html
+# You can follow the input structure provided on the website to fill further the overrides.
+# ====================================================================== #
+# If you don't have a StructureData, but you have a CIF or XYZ, or similar, file
+# you can import your structure uncommenting the following:
+# from ase.io import read
+# atoms = read('/path/to/file.cif')
+# structure = StructureData(ase=atoms)
+# structure.store()
+# structure_id =  structure.pk
+# print(f"Your structure has been stored in the database with PK={structure_id}")
+
+
+def main():
+    """Submit an IRamanSpectraWorkChain calculation."""
+    code = load_code(pw_code_label)
+    structure = load_node(structure_id)
+    kwargs = {'electronic_type': ElectronicType.INSULATOR}
+
+    builder = IRamanSpectraWorkChain.get_builder_from_protocol(
+        code=code,
+        structure=structure,
+        protocol=protocol,
+        overrides=Path(overrides_filepath),
+        **kwargs,
+    )
+
+    calc = submit(builder)
+    print(f'Submitted IRamanSpectraWorkChain with PK={calc.pk} and UUID={calc.uuid}')
+    print('Register *at least* the PK number, e.g. in you submit script.')
+    print('You can monitor the status of your calculation with the following commands:')
+    print('  * verdi process status PK')
+    print('  * verdi process list -L IRamanSpectraWorkChain # list all running IRamanSpectraWorkChain')
+    print(
+        '  * verdi process list -ap1 -L IRamanSpectraWorkChain # list all IRamanSpectraWorkChain submitted in the previous 1 day'
+    )
+    print('If the WorkChain finishes with exit code 0, then you can inspect the outputs and post-process the data.')
+    print('Use the command')
+    print('  * verdi process show PK')
+    print('To show further information about your WorkChain. When finished, you should see some outputs.')
+    print('The main output can be accessed via `load_node(PK).outputs.vibrational_data.numerical_accuracy_*`.')
+    print('You have to complete the remaning `*`, which depends upond the accuracy of the calculation.')
+    print('See also the documentation and the reference paper for further details.')
+
+
+if __name__ == '__main__':
+    """Run script."""
+    main()


### PR DESCRIPTION
Some scripts to submit IRamanSpectraWorkChain are added to illustrate further how to use the workchain in common context. For instance, how to set custom pseudo-potential families, or custom k-points, till the full input specification via the overrides.