### PR TITLE
`CI`: add `codecov` step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         -   name: Run pytest
             env:
                 AIIDA_WARN_v3: 1
-            run: pytest -sv tests --cov aiida-vibroscopy
+            run: pytest -sv --cov aiida_vibroscopy tests
 
         -   name: Upload to Codecov
             if: matrix.python-version == 3.10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,4 +68,13 @@ jobs:
         -   name: Run pytest
             env:
                 AIIDA_WARN_v3: 1
-            run: pytest -sv tests
+            run: pytest -sv tests --cov aiida-vibroscopy
+
+        -   name: Upload to Codecov
+            if: matrix.python-version == 3.10
+            uses: codecov/codecov-action@v3
+            with:
+                token: ${{ secrets.CODECOV_TOKEN }}
+                name: pytests-lammps
+                flags: pytests
+                fail_ci_if_error: true

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 75%
+        threshold: 0.2%
+    patch:
+      default:
+        target: 70%
+        threshold: 0.2%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,10 @@ pre-commit = [
 tests = [
     'pgtest~=1.3',
     'pytest~=6.0',
+    'coverage[toml]',
+    'pytest-cov',
     'pytest-regressions~=2.3',
+    'pytest-timeout',
 ]
 docs = [
     'myst-nb~=1.0.0',


### PR DESCRIPTION
The code coverage check is added to help keeping good quality of the project and covered as much as possible with tests that actually uses the majority of the routines.