### PR TITLE
Fix some docstrings and reports

### DIFF
--- a/src/aiida_vibroscopy/workflows/dielectric/base.py
+++ b/src/aiida_vibroscopy/workflows/dielectric/base.py
@@ -144,7 +144,7 @@ class DielectricWorkChain(WorkChain, ProtocolMixin):  # pylint: disable=too-many
             non_db=True,
             validator=cls._validate_properties,
             help=(
-                'Valid inputs are: \n \n * '.join(f'{flag_name}' for flag_name in cls._AVAILABLE_PROPERTIES)
+                'Valid inputs are:'+'\n * '.join(f'{flag_name}' for flag_name in cls._AVAILABLE_PROPERTIES)
             )
         )
         spec.input(

--- a/src/aiida_vibroscopy/workflows/dielectric/numerical_derivatives.py
+++ b/src/aiida_vibroscopy/workflows/dielectric/numerical_derivatives.py
@@ -49,15 +49,15 @@ class NumericalDerivativesWorkChain(WorkChain):
 
     To understand, let's review the approach.In central differencs approach
     we need the evaluation of the function at the value we want
-    the derivative (in our case at :math:`\mathcal{E}=0`,
+    the derivative (in our case at :math:`\\mathcal{E}=0`,
     E is the electric field), and at
     displaced positions from this value.
     The evaluation of the function at these points will
     have weights (or coefficients), which depend on order and accuracy.
     For example:
 
-    - :math:`\frac{df}{dx} = \frac{ 0.5 \cdot f(+1.0 \cdot h) -0.5 \cdot f(-1.0 \cdot h) }{h} +\mathcal{O}(h^2)`
-    - :math:`\frac{d^2 f}{dx^2} = \frac{ 1.0 \cdot f(+1.0 \cdot h) -2.0 \cdot f(0. \cdot h) +1.0 \cdot f(-1.0 \cdot h) }{h^2} +\mathcal{O}(h^2)`
+    - :math:`\\frac{df}{dx} = \\frac{ 0.5 \\cdot f(+1.0 \\cdot h) -0.5 \\cdot f(-1.0 \\cdot h) }{h} +\\mathcal{O}(h^2)`
+    - :math:`\\frac{d^2 f}{dx^2} = \\frac{ 1.0 \\cdot f(+1.0 \\cdot h) -2.0 \\cdot f(0. \\cdot h) +1.0 \\cdot f(-1.0 \\cdot h) }{h^2} +\\mathcal{O}(h^2)`
 
     Referring to the coefficients for each step as :math:`c_i`,
     where `i` is an integer, our convention is
@@ -71,7 +71,7 @@ class NumericalDerivativesWorkChain(WorkChain):
     | ...
 
     This way to creating an analogous of an array with
-    coefficients :math:`[c_1,c_{-1},c_2,c_{-2}, \dots]`.
+    coefficients :math:`[c_1,c_{-1},c_2,c_{-2}, \\dots]`.
 
     These dictionaries are going to be put as sub-dictionary
     in a general `data` dictionary. Each sub-dict

--- a/src/aiida_vibroscopy/workflows/phonons/base.py
+++ b/src/aiida_vibroscopy/workflows/phonons/base.py
@@ -451,7 +451,7 @@ class PhononWorkChain(WorkChain, ProtocolMixin):
                 else:
                     self.report(
                         f'PwBaseWorkChain with <PK={workchain.pk}> failed'
-                        'with exit status {workchain.exit_status}'
+                        f'with exit status {workchain.exit_status}'
                     )
                     failed_runs.append(workchain.pk)
 


### PR DESCRIPTION
Fixes #61

The PhononWorkChain was missing an 'f' string, thus missing to report the `exit_status` of possible failed child WorkChains. The DielectricWorkChain had the `property` input badly documented.