### PR TITLE
Symmetry: use only point group symmetry

### DIFF
--- a/src/aiida_vibroscopy/calculations/symmetry.py
+++ b/src/aiida_vibroscopy/calculations/symmetry.py
@@ -196,8 +196,7 @@ def get_connected_fields_with_operations(
     :return: tuple containing equivalent fields and associated rotations and translations
     """
     lattice = phonopy_instance.unitcell.cell
-    # We should probably use only the point group operations.
-    # Technically, this implementation should not cause any conceptual issue.
+    # We use only the point group operations.
     operations = phonopy_instance.symmetry.symmetry_operations
     rotations = operations['rotations']
     translations = operations['translations']
@@ -205,8 +204,9 @@ def get_connected_fields_with_operations(
     directions = []
 
     for r, t in zip(rotations, translations):
-        r_cart = similarity_transformation(lattice.T, r)
-        directions.append(tuple(np.dot(r_cart, field_direction).round(2).tolist()))
+        if np.all(np.isclose(t, [0, 0, 0])):
+            r_cart = similarity_transformation(lattice.T, r)
+            directions.append(tuple(np.dot(r_cart, field_direction).round(2).tolist()))
 
     directions = [list(direction) for direction in set(directions)]
 
@@ -232,13 +232,14 @@ def get_connected_fields_with_operations(
     directions_copy = []
 
     for r, t in zip(rotations, translations):
-        r_cart = similarity_transformation(lattice.T, r)
-        field_cart = np.dot(r_cart, field_direction).round(2).tolist()
-        if field_cart in directions:
-            rotations_set.append(r)
-            translations_set.append(t)
-            directions_copy.append(field_cart)
-            directions.remove(field_cart)
+        if np.all(np.isclose(t, [0, 0, 0])):
+            r_cart = similarity_transformation(lattice.T, r)
+            field_cart = np.dot(r_cart, field_direction).round(2).tolist()
+            if field_cart in directions:
+                rotations_set.append(r)
+                translations_set.append(t)
+                directions_copy.append(field_cart)
+                directions.remove(field_cart)
 
     return np.array(directions_copy, dtype='int32'), np.array(rotations_set, dtype='int32'), np.array(translations_set)
 


### PR DESCRIPTION
The point symmetry group should be used instead of the space group, here by avoiding fractional translations.