### PR TITLE
Deps: constrain phonopy and spglib versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.10']
+                python-version: ['3.10','3.12']
 
         services:
             rabbitmq:
@@ -75,6 +75,6 @@ jobs:
             uses: codecov/codecov-action@v3
             with:
                 token: ${{ secrets.CODECOV_TOKEN }}
-                name: pytests-vibroscopy3.9
+                name: pytests-vibroscopy3.10
                 flags: pytests
                 fail_ci_if_error: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dependencies = [
     "aiida-core>=2.2.2,<3.0.0",
     "aiida-quantumespresso>=4.3.0",
     "aiida-phonopy>=1.1.3",
-    "phonopy>=2.19.0,<3.0.0",
+    "spglib<2.5",
+    "phonopy>=2.19.0,<=2.25.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Tests fail with recent versions of phonopy and spglib.
From spglib v2.5, some API and functionality have changed,
and phonopy seems to not be functioning as expected
since v2.26 onwards.