### PR TITLE
:rocket: Release v1.1.1

### DIFF
--- a/.github/workflows/update_changelog.py
+++ b/.github/workflows/update_changelog.py
@@ -40,7 +40,7 @@ def update_changelog():
     print('🔍 Checking the current version number')
     current_changelog = Path('CHANGELOG.md').read_text(encoding='utf-8')
 
-    from aiida_quantumespresso import __version__
+    from aiida_vibroscopy import __version__
 
     if str(__version__) in current_changelog:
         print('🛑 Current version already in `CHANGELOG.md`. Skipping...')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+## v1.1.1
+
+This minor release adds the new AiiDA contributor license agreement (CLA), and its GitHub bot,
+along with some dependency contraints for phonopy. The latest versions of phonopy (>v2.26)
+break the tests. While figuring out why, we patch this until a solution is found.
+
+### 🐛 Bug fixes
+
+* Deps: constrain phonopy and spglib versions [[3a3e3d1](https://github.com/aiidateam/aiida-quantumespresso/commit/3a3e3d117e34c6a66fcdc74e1e21c6263c203565)]
+
+### 📚 Documentation
+
+* Fix some docstrings and reports [[3ee9e7c](https://github.com/aiidateam/aiida-quantumespresso/commit/3ee9e7cbd2f5e6b8f15229dafbed58ae7ef4fa0d)]
+* Update main paper reference[[504c1b7](https://github.com/aiidateam/aiida-quantumespresso/commit/504c1b7b65a8852395d0ff3ec7271cb8c05c6931)]
+
+### 🔧 Maintenance
+
+* CLA: update and remove old cla-bot [[32bd829](https://github.com/aiidateam/aiida-quantumespresso/commit/32bd829987751deba056b7bfa739f6c82cf89d3e)]
+* @bastonero has signed the CLA in bastonero/aiida-vibroscopy#78[[e83739f](https://github.com/aiidateam/aiida-quantumespresso/commit/e83739f6aaecfcb304f8cac3da6d54b93f0fafb7)]
+* Add the AiiDA CLA [[df2cade](https://github.com/aiidateam/aiida-quantumespresso/commit/df2cade1bf200b8a2dd7004a48e40b118257f134)]
+* Add CLA bot [[3ba3e9e](https://github.com/aiidateam/aiida-quantumespresso/commit/3ba3e9e9f094106254b1a8ee4c97b85e66b41f85)]
+
+### ⬆️ Update dependencies
+
+* Deps: constrain phonopy and spglib versions [[3a3e3d1](https://github.com/aiidateam/aiida-quantumespresso/commit/3a3e3d117e34c6a66fcdc74e1e21c6263c203565)]
+
+
+
+
 ## v1.1.0
 
 This minor release includes new post-processing utilities, a small breaking change in [[42503f3]](https://github.com/bastonero/aiida-vibroscopy/commit/42503f312d9a812cfc46d4c4a03a78641201e1d3) with regards to reference system for non-analytical and polarization directions. Some examples providing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
 ]
 keywords = ['aiida', 'workflows']
 requires-python = '>=3.8'

--- a/src/aiida_vibroscopy/__init__.py
+++ b/src/aiida_vibroscopy/__init__.py
@@ -7,4 +7,4 @@
 # For further information on the license, see the LICENSE.txt file              #
 #################################################################################
 """AiiDA plugin for vibrational spectoscopy using Quantum ESPRESSO."""
-__version__ = '1.1.0'
+__version__ = '1.1.1'


### PR DESCRIPTION
Minor release that mainly patches the code against newer (> v2.26) phonopy versions, which appear to break the tests. The new AiiDA contributor license agreement is also added, and the old clabot is removed.