### PR TITLE
`DielectricWorkChain`: fix validator

### DIFF
--- a/src/aiida_vibroscopy/workflows/dielectric/base.py
+++ b/src/aiida_vibroscopy/workflows/dielectric/base.py
@@ -98,11 +98,12 @@ def validate_parent_scf(parent_scf, _):
 
 def validate_inputs(inputs, _):
     """Validate the entire inputs namespace."""
-    if 'electric_field_step' in inputs['central_difference'] and 'accuracy' not in inputs['central_difference']:
-        return (
-            'cannot evaluate numerical accuracy when `electric_field_step` '
-            'is specified but `accuracy` is not in `central_difference`'
-        )
+    if 'central_difference' in inputs:
+        if 'electric_field_step' in inputs['central_difference'] and 'accuracy' not in inputs['central_difference']:
+            return (
+                'cannot evaluate numerical accuracy when `electric_field_step` '
+                'is specified but `accuracy` is not in `central_difference`'
+            )
 
     if 'kpoints_parallel_distance' in inputs and 'kpoints_distance' not in inputs['scf']:
         return '`kpoints_parallel_distance` works only when specifying `scf.kpoints_distance`'


### PR DESCRIPTION
The validator would complain if the `central_difference` input is not present for some reason, e.g., because of modification in the main aiida-core/plumpy functionality. We therefore add a simple check to avoid having issues.