### PR TITLE
`Properties`: reduce mesh for phonon mesh interpolation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,11 @@ classifiers = [
 keywords = ['aiida', 'workflows']
 requires-python = '>=3.8'
 dependencies = [
-    "aiida-core>=2.2.2,<3.0.0",
-    "aiida-quantumespresso>=4.10.0",
-    "aiida-phonopy>=1.1.3",
-    "spglib<2.5",
-    "phonopy>=2.19.0,<=2.25.0",
+    "aiida-core~=2.3",
+    "aiida-quantumespresso~=4.10",
+    "aiida-phonopy~=1.1",
+    "spglib~=2.2.0",
+    "phonopy~=2.19,<=2.25.0",
 ]
 
 [project.urls]

--- a/src/aiida_vibroscopy/common/properties.py
+++ b/src/aiida_vibroscopy/common/properties.py
@@ -15,5 +15,5 @@ class PhononProperty(enum.Enum):
 
     NONE = None
     BANDS = {'band': 'auto'}
-    DOS = {'dos': True, 'mesh': 1000, 'write_mesh': False}
-    THERMODYNAMIC = {'tprop': True, 'mesh': 1000, 'write_mesh': False}
+    DOS = {'dos': True, 'mesh': 300, 'write_mesh': False}
+    THERMODYNAMIC = {'tprop': True, 'mesh': 300, 'write_mesh': False}


### PR DESCRIPTION
The value of 1000 for mesh interpolation is extreme and unnecessary.
Phonopy defaults it to 100, which corresponds already to very large
cells of about 50'000 atoms. We therefore choose 300, which is a
very reasonable value and it is still feasible to run on common laptops.