### PR TITLE
Deps: support aiida-qe v5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ keywords = ['aiida', 'workflows']
 requires-python = '>=3.10'
 dependencies = [
     "aiida-core~=2.8",
-    "aiida-quantumespresso~=4.10,!=4.14",
+    "aiida-quantumespresso>=4.10,!=4.14,<6.0",
     "aiida-phonopy~=1.5",
     "spglib~=2.6",
     "phonopy~=3.0",


### PR DESCRIPTION
The new version has no breaking changes that affect the workflows implemented in this plugin, so we can update the dependency up to v6.0.