### PR TITLE
Fix dielectric NSCF output access

### DIFF
--- a/src/aiida_vibroscopy/workflows/dielectric/base.py
+++ b/src/aiida_vibroscopy/workflows/dielectric/base.py
@@ -641,10 +641,10 @@ class DielectricWorkChain(WorkChain, ProtocolMixin):  # pylint: disable=too-many
 
     def check_insulator(self):
         """Check whether the system is an insulator after the nscf."""
-        workchain = self.ctx.nscf.outputs
+        outputs = self.ctx.nscf.outputs
 
-        bands = workchain.outputs.output_band
-        parameters = workchain.outputs.output_parameters.get_dict()
+        bands = outputs.output_band
+        parameters = outputs.output_parameters.get_dict()
 
         fermi_energy = parameters['fermi_energy']
         number_electrons = parameters['number_of_electrons']

--- a/tests/workflows/dielectric/test_base.py
+++ b/tests/workflows/dielectric/test_base.py
@@ -285,6 +285,34 @@ def test_inspect_nscf(generate_workchain_dielectric, generate_base_scf_workchain
     assert result == expected_result
 
 
+@pytest.mark.usefixtures('aiida_profile')
+def test_check_insulator(generate_workchain_dielectric, monkeypatch):
+    """Test `DielectricWorkChain.check_insulator`."""
+    from aiida import orm
+    from aiida.common import LinkType
+
+    nscf = orm.WorkflowNode().store()
+
+    bands = orm.BandsData().store()
+    bands.base.links.add_incoming(nscf, link_type=LinkType.RETURN, link_label='output_band')
+
+    parameters = orm.Dict({
+        'fermi_energy': 0.0,
+        'number_of_electrons': 2,
+    }).store()
+    parameters.base.links.add_incoming(nscf, link_type=LinkType.RETURN, link_label='output_parameters')
+
+    monkeypatch.setattr(
+        'aiida_vibroscopy.workflows.dielectric.base.find_bandgap',
+        lambda *args, **kwargs: (True, 1.0),
+    )
+
+    process = generate_workchain_dielectric()
+    process.ctx.nscf = nscf
+
+    assert process.check_insulator() is None
+
+
 @pytest.mark.parametrize(
     ('parameters', 'values'),
     (


### PR DESCRIPTION
## Summary

- Read the NSCF outputs directly in `check_insulator`.
- Add a regression test covering the insulating-system path.

## Context

The metallic-ground-state check added in #104 stores `self.ctx.nscf.outputs` and then dereferences `.outputs` a second time. This raises `NotExistentAttributeError` after an otherwise successful NSCF calculation.

@bastonero @edan-bainglass, could you please have a look at this small correction?

## Validation

- `pytest -q tests/workflows/dielectric/test_base.py`
- `ruff check src/aiida_vibroscopy/workflows/dielectric/base.py tests/workflows/dielectric/test_base.py`
- Complete local AiiDAlab silicon workflow with Python 3.12.11 and AiiDA 2.8.0: dielectric critical-field estimation, finite-field SCFs, numerical derivatives, phonons, and final Phonopy calculations all completed successfully.

Prepared with Codex assistance.